### PR TITLE
Update Positions.xml

### DIFF
--- a/Positions.xml
+++ b/Positions.xml
@@ -616,7 +616,7 @@
         <Map Name="Nadi/NFNA_RWY10" />
       </Maps>
       <ATIS>
-        <Editor Airport="NFFA" Frequency="128.5" />
+        <Editor Airport="NFNA" Frequency="128.5" />
         <Window Airport="NFNA" />
       </ATIS>
       <Strips Mode="Beacon" Sort="Alpha">


### PR DESCRIPTION
Fixing typo for Nausori ATIS default ICAO.

By default it was incorrectly NFFA, not NFNA